### PR TITLE
fix ubuntu eoan repositories due to EOL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ ENV IQFEED_LOG_LEVEL 0xB222
 
 ENV WINEDEBUG -all
 
+ADD sources.list /etc/apt/sources.list
+
 RUN dpkg --add-architecture i386 && \
     apt-get update && apt-get upgrade -yq && \
     apt-get install -yq --no-install-recommends \

--- a/sources.list
+++ b/sources.list
@@ -1,0 +1,8 @@
+## EOL upgrade sources.list
+# Required
+deb http://old-releases.ubuntu.com/ubuntu/ eoan main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-updates main restricted universe multiverse
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-security main restricted universe multiverse
+
+# Optional
+deb http://old-releases.ubuntu.com/ubuntu/ eoan-backports main restricted universe multiverse


### PR DESCRIPTION
Can't build image due to Ubuntu 19.10 end of life.